### PR TITLE
Integrate tailwind responsive with existing css

### DIFF
--- a/Diambars-Sublim/frontend/Diambars-Sublim-Public/src/pages/contact/contact.css
+++ b/Diambars-Sublim/frontend/Diambars-Sublim-Public/src/pages/contact/contact.css
@@ -82,7 +82,6 @@
   margin: 120px auto;
   position: relative;
   z-index: 1;
-  gap: 1rem;
 }
 
 /* ELIMINADO: flex, flex-direction, align-items, justify-content */
@@ -107,7 +106,6 @@
   align-items: center;
   position: relative;
   border-radius: 20px;
-  padding: 2.5rem;
   text-align: center;
   font-size: 1rem;
   color: #3F2724;
@@ -148,7 +146,6 @@
   display: flex;
   align-items: center;
   margin-bottom: 2rem;
-  gap: 1rem;
 }
 
 .contact-info-item:last-child {
@@ -201,7 +198,6 @@
 .contact-form-container {
   position: relative;
   border-radius: 20px;
-  padding: 2.5rem;
   text-align: center;
   font-size: 1rem;
   color: #3F2724;
@@ -256,7 +252,6 @@
   display: flex;
   align-items: center;
   flex-direction: column;
-  gap: 1rem;
 }
 
 .contact-label {

--- a/Diambars-Sublim/frontend/Diambars-Sublim-Public/tailwind.config.js
+++ b/Diambars-Sublim/frontend/Diambars-Sublim-Public/tailwind.config.js
@@ -8,6 +8,7 @@ export default {
     extend: {
       fontFamily: {
         inter: ['Inter', 'sans-serif'],
+        spectral: ['Spectral', 'serif'],
       },
     },
   },


### PR DESCRIPTION
Integrate Tailwind CSS for responsive design on the contact page by configuring the 'Spectral' font and removing conflicting CSS layout properties.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f657f1c-ad27-4238-b881-9dcd98cd11b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f657f1c-ad27-4238-b881-9dcd98cd11b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

