### PR TITLE
Fix menu component fragment child error

### DIFF
--- a/Diambars-Sublim/frontend/Diambars-Sublim-PrivateAdmin/src/components/DesignCard/DesignCard.jsx
+++ b/Diambars-Sublim/frontend/Diambars-Sublim-PrivateAdmin/src/components/DesignCard/DesignCard.jsx
@@ -671,30 +671,32 @@ const DesignCard = ({
         transformOrigin={{ horizontal: 'right', vertical: 'top' }}
         anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
       >
-        {visibleOptions.map((option, index) => (
-          <React.Fragment key={option.label}>
-            {option.divider && index > 0 && (
-              <Box sx={{ 
+        {visibleOptions.map((option, index) => [
+          option.divider && index > 0 ? (
+            <Box 
+              key={`divider-${index}`}
+              sx={{ 
                 height: '1px', 
                 backgroundColor: alpha('#1F64BF', 0.08), 
                 margin: '4px 16px' 
-              }} />
-            )}
-            <MenuItem
-              onClick={option.action}
-              sx={{ 
+              }} 
+            />
+          ) : null,
+          <MenuItem
+            key={option.label}
+            onClick={option.action}
+            sx={{ 
+              color: option.color,
+              '& svg': { 
                 color: option.color,
-                '& svg': { 
-                  color: option.color,
-                  flexShrink: 0
-                }
-              }}
-            >
-              <option.icon size={16} weight="bold" />
-              {option.label}
-            </MenuItem>
-          </React.Fragment>
-        ))}
+                flexShrink: 0
+              }
+            }}
+          >
+            <option.icon size={16} weight="bold" />
+            {option.label}
+          </MenuItem>
+        ]).flat().filter(Boolean)}
       </Menu>
     </DesignCardContainer>
   );


### PR DESCRIPTION
Refactor `Menu` children in `DesignCard` to use an array instead of `React.Fragment` to resolve a MUI error.

The `Menu` component in MUI does not accept `React.Fragment` as a direct child, causing the error "MUI: The Menu component doesn't accept a Fragment as a child. Consider providing an array instead." The fix involves mapping to an array of elements (including conditional dividers) and then flattening and filtering this array to ensure direct valid children for the `Menu` component.

---
<a href="https://cursor.com/background-agent?bcId=bc-b57cece6-269b-4ebb-8c4c-7de17e0767c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b57cece6-269b-4ebb-8c4c-7de17e0767c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

